### PR TITLE
Add .gitignore with .DS_Store and Xcode patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+# macOS
+.DS_Store
+
+# Xcode
+*.xcuserstate
+xcuserdata/
+*.xccheckout
+*.moved-aside
+DerivedData/
+*.hmap
+*.ipa
+*.xcscmblueprint
+
+# Swift Package Manager
+.build/
+.swiftpm/
+
+# CocoaPods
+Pods/
+
+# Carthage
+Carthage/Build/
+
+# Fastlane
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output
+
+# Code Injection
+*.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist


### PR DESCRIPTION
## Summary
- Add .gitignore file to prevent tracking of system and build files
- Include .DS_Store to prevent macOS metadata files from being committed
- Add common Xcode and iOS development patterns

## Changes
- Created `.gitignore` with:
  - macOS system files (.DS_Store)
  - Xcode user data and build artifacts
  - Swift Package Manager directories
  - Dependency manager directories (CocoaPods, Carthage)
  - Fastlane output

## Test plan
- [x] Verify .DS_Store files are ignored
- [x] Confirm Xcode user data is not tracked
- [x] Check that build directories are excluded

🤖 Generated with [Claude Code](https://claude.ai/code)